### PR TITLE
Fix: Bug 5 mas implementacion de guardado en directorio configurable

### DIFF
--- a/compilation.bat
+++ b/compilation.bat
@@ -1,3 +1,3 @@
 @echo off
-nvcc .\src\main.cpp .\src\host\matrix_io.cpp .\src\host\validations.cpp .\src\device\launches.cu .\src\device\kernel_matrix_multiplication.cu -o CUDA_matrix_multiplication -O3 -arch=sm_80 -lineinfo -diag-suppress=611 -I src/host -I src/device
+nvcc -std=c++17 .\src\main.cpp .\src\host\matrix_io.cpp .\src\host\validations.cpp .\src\device\launches.cu .\src\device\kernel_matrix_multiplication.cu -o CUDA_matrix_multiplication -O3 -arch=sm_80 -lineinfo -diag-suppress=611 -I src/host -I src/device
 pause

--- a/src/host/config.hpp
+++ b/src/host/config.hpp
@@ -9,7 +9,7 @@
  * Esta constante define la ruta del archivo binario donde se almacena la matriz A.
  * Se recomienda actualizarla para que sea configurable de manera dinámica.
  */
-const std::string MATRIX_A_FILE_PATH = "data/A_MATRIX.bin";
+const std::string MATRIX_A_FILE_PATH = "C:\\Users\\feder\\Documents\\Especializacion\\Programming Massively Parallel Processors\\Materias\\1 - Conceptos fundamentales\\Practico\\capitulo_3\\matrix_multiplication\\data\\A_MATRIX.bin";
 
 /**
  * @brief Ruta del archivo binario que contiene la matriz B.
@@ -17,6 +17,12 @@ const std::string MATRIX_A_FILE_PATH = "data/A_MATRIX.bin";
  * Esta constante define la ruta del archivo binario donde se almacena la matriz B.
  * Se recomienda actualizarla para que sea configurable de manera dinámica.
  */
-const std::string MATRIX_B_FILE_PATH = "data/B_MATRIX.bin";
+const std::string MATRIX_B_FILE_PATH = "C:\\Users\\feder\\Documents\\Especializacion\\Programming Massively Parallel Processors\\Materias\\1 - Conceptos fundamentales\\Practico\\capitulo_3\\matrix_multiplication\\data\\B_MATRIX.bin";
+
+/**
+ * @brief Ruta del archivo de metadatos de la matriz resultante C correspondiente a la ejecucion del programa.
+ * 
+ */
+const std::string METADATA_OUT_PATH = "C:\\Users\\feder\\Documents\\Especializacion\\Programming Massively Parallel Processors\\Materias\\1 - Conceptos fundamentales\\Practico\\capitulo_3\\matrix_multiplication\\data\\";
 
 #endif // CONFIG_HPP

--- a/src/host/matrix_io.hpp
+++ b/src/host/matrix_io.hpp
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <filesystem>
 #include "kernel_matrix_multiplication_data.cuh"
 
 /**
@@ -42,5 +43,8 @@ void writeKernelDataToCSV(const KernelData& data);
  * @return std::string El nombre del archivo generado.
  */
 std::string generateFileName(const KernelData& data);
+
+
+std::filesystem::path generateFilePath(const std::string& fileName);
 
 #endif // MATRIX_IO_HPP

--- a/src/host/validations.cpp
+++ b/src/host/validations.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <iostream>
+#include <filesystem>
 #include "validations.hpp"
 
 /**
@@ -22,4 +23,19 @@
  */
 bool is_matrix_product_permitted(unsigned long long colsA, unsigned long long rowsB) {
     return colsA == rowsB;
+}
+
+/**
+ * @brief Checks if a file exists in the filesystem.
+ * 
+ * This function takes a file name as input and returns a boolean indicating
+ * whether the specified file exists. It uses the std::filesystem library to
+ * perform the existence check.
+ *
+ * @param fileName The name (and path) of the file to check.
+ * @return true If the file exists.
+ * @return false If the file does not exist.
+ */
+bool fileExists(const std::string& fileName) {
+    return std::filesystem::exists(fileName);
 }

--- a/src/host/validations.hpp
+++ b/src/host/validations.hpp
@@ -19,4 +19,18 @@
  */
 bool is_matrix_product_permitted(unsigned long long colsA, unsigned long long rowsB);
 
+/**
+ * @brief Checks if a file exists in the filesystem.
+ * 
+ * This function takes a file name as input and returns a boolean indicating
+ * whether the specified file exists. It uses the std::filesystem library to
+ * perform the existence check.
+ *
+ * @param fileName The name (and path) of the file to check.
+ * @return true If the file exists.
+ * @return false If the file does not exist.
+ */
+bool fileExists(const std::string& fileName);
+
+
 #endif // VALIDATIONS_HPP


### PR DESCRIPTION
Cierra #5 

En el siguiente PR se efectuan los siguientes cambios:

 *  Se soluciona el bug de escritura continua de la cabecera del archivo .csv por cada ejecucion
 *  De yapa se puede configurar la salida del archivo en ela rchivo `config.hpp`

